### PR TITLE
`/api/auth` で `esm.co.jp` アカウントの認証ができるようになった

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
+# dotenv or direnv environment variables file
 .env
+.envrc
 
 # next.js build output
 .next
@@ -66,3 +67,5 @@ typings/
 # Polymer Build
 build
 
+# application secret
+secret.yaml

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,29 @@
+const router = require('express-promise-router')();
+
+const {OAuth2Client} = require('google-auth-library');
+const client = new OAuth2Client(process.env.CLIENT_ID);
+
+const verify = async token => {
+  const ticket = await client.verifyIdToken({
+    idToken: token,
+    audience: process.env.CLIENT_ID,
+  });
+  return ticket.getPayload();
+};
+
+router.post('/', async (req, res) => {
+  const idTokenString = req.body.idToken;
+  const payload = await verify(idTokenString);
+  if (!payload) {
+    res.sendStatus(400);
+  } else {
+    const domain = payload.hd;
+    if ("esm.co.jp" != domain) {
+      res.sendStatus(400);
+    } else {
+      res.sendStatus(200);
+    }
+  }
+})
+
+module.exports = router;

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,6 @@
 # [START app_yaml]
 runtime: nodejs10
+
+includes:
+- secret.yaml
 # [END app_yaml]

--- a/index.js
+++ b/index.js
@@ -2,14 +2,15 @@
 
 // [START app]
 const express = require('express');
+const bodyParser = require('body-parser');
+const auth = require('./api/auth');
 const app = express();
 
-app.use(express.static('public'));
-app.use('/node_modules', express.static('node_modules'));
+app.use(express.static('build/es6-unbundled/public'));
+app.use('/node_modules', express.static('build/es6-unbundled/node_modules'));
 
-app.get('/api', (req, res) => {
-  res.send('Hello from App Engine!');
-});
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use('/api/auth', auth);
 
 // Listen to the App Engine-specified port, or 8080 otherwise
 const PORT = process.env.PORT || 8080;

--- a/package-lock.json
+++ b/package-lock.json
@@ -804,6 +804,14 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
@@ -913,6 +921,15 @@
       "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1853,6 +1870,11 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -2140,6 +2162,14 @@
         "parse5": "^4.0.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2149,6 +2179,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2385,6 +2428,21 @@
         "vary": "~1.1.2"
       }
     },
+    "express-promise-router": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-3.0.3.tgz",
+      "integrity": "sha1-Xm0ipaPwE9cYMxcv6NereAw/a3A=",
+      "requires": {
+        "is-promise": "^2.1.0",
+        "lodash.flattendeep": "^4.0.0",
+        "methods": "^1.0.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "external-editor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -2525,6 +2583,24 @@
       "integrity": "sha512-Yal9dssXDtme83dHDN2Mc+5FmnrTgnG1OS7imCaSjUdMFZJ8ZmvBhdxeSIHSr2GPsSK07PrR3nBdZLRieVeK3Q==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2582,6 +2658,16 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gcp-metadata": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.7.0.tgz",
+      "integrity": "sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==",
+      "requires": {
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
+        "retry-axios": "0.3.2"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -2621,6 +2707,36 @@
       "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
     },
+    "google-auth-library": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-2.0.2.tgz",
+      "integrity": "sha512-FURxmo1hBVmcfLauuMRKOPYAPKht3dGuI2wjeJFalDUThO0HoYVjr4yxt5cgYSFm1dgUpmN9G/poa7ceTFAIiA==",
+      "requires": {
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.7.0",
+        "gtoken": "^2.3.0",
+        "https-proxy-agent": "^2.2.1",
+        "jws": "^3.1.5",
+        "lru-cache": "^5.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
+      "integrity": "sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==",
+      "requires": {
+        "node-forge": "^0.7.5",
+        "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -2638,6 +2754,25 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
+    },
+    "gtoken": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
+      "requires": {
+        "axios": "^0.18.0",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.4",
+        "mime": "^2.2.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+        }
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -2693,6 +2828,30 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "iconv-lite": {
@@ -2780,8 +2939,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2858,8 +3016,7 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -3016,6 +3173,25 @@
       "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
       "dev": true
     },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3086,6 +3262,11 @@
         "lodash._isiterateecall": "^3.0.0"
       }
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -3134,6 +3315,14 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
       }
     },
     "math-random": {
@@ -3343,6 +3532,11 @@
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
       "dev": true
     },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
@@ -3512,6 +3706,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -16047,6 +16246,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -16108,8 +16312,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
       "version": "0.16.2",
@@ -16661,6 +16864,11 @@
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
       }
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "@polymer/paper-button": "^3.0.0-pre.18",
     "@polymer/paper-input": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",
-    "express": "^4.16.4"
+    "body-parser": "^1.18.3",
+    "express": "^4.16.4",
+    "express-promise-router": "^3.0.3",
+    "google-auth-library": "^2.0.2"
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.0.0",

--- a/polymer.json
+++ b/polymer.json
@@ -3,14 +3,11 @@
   "shell": "public/src/dakoku-app/dakoku-app.js",
   "sources": [
     "public/src/dakoku-app/*.js",
-    "public/service-worker.js",
-    "package.json"
+    "public/service-worker.js"
   ],
   "extraDependencies": [
     "public/manifest.json",
-    "node_modules/@webcomponents/webcomponentsjs/**",
-    "app.yaml",
-    "index.js"
+    "node_modules/@webcomponents/webcomponentsjs/**"
   ],
   "moduleResolution": "node",
   "npm": true,

--- a/public/src/dakoku-app/dakoku-app.js
+++ b/public/src/dakoku-app/dakoku-app.js
@@ -20,7 +20,7 @@ class DakokuApp extends PolymerElement {
 
     <google-signin brand="google" height="standard" client-id="512704348312-hhq0htjk798tahele7tf32n2ckc4supa.apps.googleusercontent.com"></google-signin>
 
-    <iron-ajax id="ajax" method="POST" url="/auth" content-type="application/x-www-form-urlencoded" body="[[tokenObject]]" on-response="handleAuthSuccess" on-error="handleAuthError"></iron-ajax>
+    <iron-ajax id="ajax" method="POST" url="/api/auth" content-type="application/x-www-form-urlencoded" body="[[tokenObject]]" on-response="handleAuthSuccess" on-error="handleAuthError"></iron-ajax>
 
     <template is="dom-if" if="{{isAuthorized}}">
       <h2>打刻アプリにようこそ [[email]]!</h2>

--- a/secret.yaml.template
+++ b/secret.yaml.template
@@ -1,0 +1,2 @@
+env_variables:
+  CLIENT_ID: "xxxxxxxxxxxxxxxxxx.apps.googleusercontent.com"


### PR DESCRIPTION
* `google-auth-library` のトークン認証が非同期なので `express-promise-router` を使って非同期ルーティングする。[参考URL](https://qiita.com/yukin01/items/1a36606439123525dc6d#%E3%83%91%E3%82%BF%E3%83%BC%E3%83%B33-router-%E5%81%B4%E3%81%A7%E9%9D%9E%E5%90%8C%E6%9C%9F%E4%BE%8B%E5%A4%96%E3%82%92%E5%87%A6%E7%90%86%E3%81%95%E3%81%9B%E3%82%8B)
* クライアントIDは、環境変数から取得するようにした。GAEでは `secret.yaml` から読み込むように。ローカル実行のときは `direnv` などで環境変数に入れるようにしてください。
* WebComponentsのビルド後のパスにnode.jsのサーバー実装は入れないようにしました（node_modulesの管理がよくわからなくなってしまうため）
* [Googleの認証確認方法の参考URL](https://developers.google.com/identity/sign-in/web/backend-auth)