### PR TITLE
dakoku-iotからリクエストを受けて、dakoku-scriptへ転送できるようになった

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,26 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+/node_modules
+
+.editorconfig
+.brackets.json
+.python-version
+.eslintignore
+.eslintrc
+
+/public
+*.pem
+secret.yaml.template

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Task Queue **only** create from CLI.
 
 [App Engine キューの作成](https://cloud.google.com/tasks/docs/creating-appengine-queues?hl=ja)
 
+注意) `転送設定` で `dakoku-script` サービスへ `--routing-override` を指定すること
+
 ## Run Local
 
 ### Environment

--- a/api/dakoku/dakoku-request.js
+++ b/api/dakoku/dakoku-request.js
@@ -9,7 +9,7 @@ module.exports = async ({email, password, action}) => {
   const task = {
     appEngineHttpRequest: {
       httpMethod: 'POST',
-      relativeUri: '/script',
+      relativeUri: '/',
       headers: {
         'Content-Type': 'application/json'
       },

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,4 +1,0 @@
-dispatch:
-  # dakoku-scriptへのパス
-  - url: "*/script/*"
-    service: dakoku-script

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   "version": "",
   "main": "index.js",
   "engines": {
-    "node": "~10.6.0",
+    "node": "10.x.x",
     "npm": "~6.4.1"
   },
   "scripts": {
     "start": "node index.js",
     "build": "cp -R node_modules/@google-web-components/google-apis node_modules/ & polymer build -v",
+    "deploy": "gcloud app deploy",
     "test": "DATASTORE_EMULATOR_HOST=localhost:8081 DATASTORE_PROJECT_ID='test' jest --runInBand",
     "lint": "eslint --fix \"**/*.js\"",
     "local": "gcloud beta emulators datastore start --no-legacy --project 'dakoku-187702' --host-port=localhost:8081 & DATASTORE_EMULATOR_HOST=localhost:8081 DATASTORE_PROJECT_ID='dakoku-187702' node index.js",


### PR DESCRIPTION
- GAEにデプロイできるようにした
- AppEngineキューをサービスへ転送するための注記をREADMEへ追加した（今回でいうと `dakoku-script` へ転送するには、dispatch設定ではなくキューの転送設定が必要だった）
- 上記の結果、dispatch設定は削除し、POST先のURLもサービスのルートに変更した
